### PR TITLE
Some utils aditions

### DIFF
--- a/lib/SrBuj/rails/action_controller/helpers.rb
+++ b/lib/SrBuj/rails/action_controller/helpers.rb
@@ -6,7 +6,8 @@ module SrBuj
         type: 'X-SRBUJ-TYPE',
         side: 'X-SRBUJ-SIDE',
         position: 'X-SRBUJ-POS',
-        time: 'X-SRBUJ-TIME'
+        time: 'X-SRBUJ-TIME',
+        raw: 'X-SRBUJ-RAW'
       }
       #=> helpfull method to return redirect_to in an js way.
       # use: js_redirect(to: root_path)

--- a/lib/SrBuj/rails/action_controller/helpers.rb
+++ b/lib/SrBuj/rails/action_controller/helpers.rb
@@ -1,12 +1,13 @@
 module SrBuj
   module ActionController
     module Helpers
-      HEADERS = { message: 'X-SRBUJ-MSG',
-                  type: 'X-SRBUJ-TYPE',
-                  side: 'X-SRBUJ-SIDE',
-                  position: 'X-SRBUJ-POS',
-                  time: 'X-SRBUJ-TIME'
-                }
+      HEADERS = {
+        message: 'X-SRBUJ-MSG',
+        type: 'X-SRBUJ-TYPE',
+        side: 'X-SRBUJ-SIDE',
+        position: 'X-SRBUJ-POS',
+        time: 'X-SRBUJ-TIME'
+      }
       #=> helpfull method to return redirect_to in an js way.
       # use: js_redirect(to: root_path)
       # use: js_redirect(reload: true)
@@ -32,6 +33,8 @@ module SrBuj
           HEADERS.each do |value, header|
             response.headers[header] = options[value].to_s if options[value]
           end
+        else
+          response.headers['X-SRBUJ-REMOVE'] = 'true'
         end
       end
     end

--- a/lib/assets/javascripts/SrBuj.js
+++ b/lib/assets/javascripts/SrBuj.js
@@ -206,11 +206,15 @@
              gMsg.textContent = options.message;
              $('body').append(gMsg);
              gMsg.className += [' alert', options.side || 'right', options.position ||  'bottom', 'srbuj-notify' ].join(' ').toLowerCase();
-             options.time = Number( options.time ) > 0 ? options.time : 2000;
-             $.SrBuj.gMsg_interval =  window.setInterval( $.SrBuj.Util.removeNotify, options.time );
+             options.time = Number(options.time) > 0 ? options.time : 2000;
+             $.SrBuj.gMsg_interval = window.setInterval( $.SrBuj.Util.removeNotify, options.time );
           },
           removeNotify: function(){
             $('#_growlingMsg').removeClass('srbuj-notify');
+          },
+          randomCode: function(size) {
+            var size = !isNaN(size) && size < 12 ? size : 12
+            return Math.random().toString(36).substring(4).substring(0, size)
           },
           link: function (user_options){
             /* This function will create a link with options, trigger it and remove the link afterwards
@@ -228,6 +232,16 @@
             if(user_options.target && user_options.href){
               var _srbujLink = document.createElement('a');
               _srbujLink.id = '_srbujLink';
+              if (user_options.force_refresh) {
+                var params     = { key: $.SrBuj.Util.randomCode(6) }
+                  , urlParams  = $.param(params)
+                  , splitedUrl = user_options.href.split(/\?.+/)
+                  , joinChar   = (splitedUrl.length > 1) ? '&'
+                                 : splitedUrl[0].match(/\?$/) ? ''
+                                   : '?';
+
+                user_options.href +=  joinChar + urlParams;
+              }
               _srbujLink.href = user_options.href;
                   delete user_options.href;
               for (var attr in user_options) {

--- a/lib/assets/javascripts/SrBuj.js
+++ b/lib/assets/javascripts/SrBuj.js
@@ -21,7 +21,15 @@
     $.SrBuj = SrBuj = {
         version: '0.9.2',
         selector: '[data-remote][data-target]',
-        notifyHeaders: { message: 'X-SRBUJ-MSG', type: 'X-SRBUJ-TYPE', side: 'X-SRBUJ-SIDE', position: 'X-SRBUJ-POS', time: 'X-SRBUJ-TIME', remove: 'X-SRBUJ-REMOVE' },
+        notifyHeaders: {
+          message  : 'X-SRBUJ-MSG',
+          type     : 'X-SRBUJ-TYPE',
+          side     : 'X-SRBUJ-SIDE',
+          position : 'X-SRBUJ-POS',
+          time     : 'X-SRBUJ-TIME',
+          remove   : 'X-SRBUJ-REMOVE',
+          raw      : 'X-SRBUJ-RAW'
+        },
         defaults: {
             '$el': undefined,
             target: undefined,
@@ -86,10 +94,10 @@
                 return respond_as.toUpperCase();
             } else
             if (dataVerb) {
-                return dataVerb.toUpperCase();
+              return dataVerb.toUpperCase();
             } else {
                 if (proto) {
-                    return replace ? 'PUT' : proto.toUpperCase();
+                  return replace ? 'PUT' : proto.toUpperCase();
                 }
             }
         },
@@ -115,7 +123,7 @@
                 };
             user_options = user_options || {};
             for ( var attr in this.defaults ) {
-                if ( this.defaults.hasOwnProperty( attr ) ) {
+                if ( this.defaults.hasOwnProperty(attr) ) {
                     options[attr] = user_options[attr] || el_options[attr] || this.defaults[attr];
                 }
             }
@@ -125,8 +133,8 @@
           if ( xhr ){
             var notify = {};
             for ( var attr in $.SrBuj.notifyHeaders )
-              if ( $.SrBuj.notifyHeaders.hasOwnProperty( attr ) ) {
-                notify[attr] =  xhr.getResponseHeader( $.SrBuj.notifyHeaders[attr] );
+              if ( $.SrBuj.notifyHeaders.hasOwnProperty(attr) ) {
+                notify[attr] = xhr.getResponseHeader($.SrBuj.notifyHeaders[attr]);
               }
               if (notify.message){ $.SrBuj.Util.notify(notify) }
               if (notify.remove){ $.SrBuj.Util.removeNotify() }
@@ -173,11 +181,11 @@
           if (error) {
             $.SrBuj.changeDom('ERROR', $error, data.responseText);
             var notify = {};
-            for ( var attr in $.SrBuj.notifyHeaders )
-              if ( $.SrBuj.notifyHeaders.hasOwnProperty( attr ) ) {
-                notify[attr] =  data.getResponseHeader( $.SrBuj.notifyHeaders[attr] );
+            for (var attr in $.SrBuj.notifyHeaders)
+              if ($.SrBuj.notifyHeaders.hasOwnProperty(attr)) {
+                notify[attr] = data.getResponseHeader($.SrBuj.notifyHeaders[attr]);
               }
-              if ( notify.message ){ $.SrBuj.Util.notify(notify) }
+              if (notify.message){ $.SrBuj.Util.notify(notify) }
           }else {
             throw 'cant find data-error on element ' + e.target + ' maybe content_type missing on response?';
           }
@@ -204,7 +212,8 @@
              }else{
                gMsg.className = 'alert-info';
              }
-             gMsg.innerHTML = options.message;
+             gMsg.innerHTML = options.raw ? options.message
+                                          : $.SrBuj.Util.decodeUTF8(options.message);
              $('body').append(gMsg);
              gMsg.className += [' alert', options.side || 'right', options.position ||  'bottom', 'srbuj-notify' ].join(' ').toLowerCase();
              if (options.time != -1) {
@@ -218,6 +227,9 @@
           randomCode: function(size) {
             var size = !isNaN(size) && size < 12 ? size : 12
             return Math.random().toString(36).substring(4).substring(0, size)
+          },
+          decodeUTF8: function(message) {
+            return decodeURIComponent(escape(message))
           },
           link: function (user_options){
             /* This function will create a link with options, trigger it and remove the link afterwards

--- a/lib/assets/javascripts/SrBuj.js
+++ b/lib/assets/javascripts/SrBuj.js
@@ -21,7 +21,7 @@
     $.SrBuj = SrBuj = {
         version: '0.9.2',
         selector: '[data-remote][data-target]',
-        notifyHeaders: { message: 'X-SRBUJ-MSG', type: 'X-SRBUJ-TYPE', side: 'X-SRBUJ-SIDE', position: 'X-SRBUJ-POS', time: 'X-SRBUJ-TIME' },
+        notifyHeaders: { message: 'X-SRBUJ-MSG', type: 'X-SRBUJ-TYPE', side: 'X-SRBUJ-SIDE', position: 'X-SRBUJ-POS', time: 'X-SRBUJ-TIME', remove: 'X-SRBUJ-REMOVE' },
         defaults: {
             '$el': undefined,
             target: undefined,
@@ -128,7 +128,8 @@
               if ( $.SrBuj.notifyHeaders.hasOwnProperty( attr ) ) {
                 notify[attr] =  xhr.getResponseHeader( $.SrBuj.notifyHeaders[attr] );
               }
-              if ( notify.message ){ $.SrBuj.Util.notify(notify) }
+              if (notify.message){ $.SrBuj.Util.notify(notify) }
+              if (notify.remove){ $.SrBuj.Util.removeNotify() }
               if ( (/javascript/).test( xhr.getResponseHeader('Content-Type') )){
                 return true;
               }
@@ -203,7 +204,7 @@
              }else{
                gMsg.className = 'alert-info';
              }
-             gMsg.textContent = options.message;
+             gMsg.innerHTML = options.message;
              $('body').append(gMsg);
              gMsg.className += [' alert', options.side || 'right', options.position ||  'bottom', 'srbuj-notify' ].join(' ').toLowerCase();
              if (options.time != -1) {

--- a/lib/assets/javascripts/SrBuj.js
+++ b/lib/assets/javascripts/SrBuj.js
@@ -245,10 +245,12 @@
             var user_options = user_options || {};
             $.extend(user_options, {remote: true, srbuj: true});
             if(user_options.target && user_options.href){
-              var _srbujLink = document.createElement('a');
-              _srbujLink.id = '_srbujLink';
+              var _srbujLink = document.createElement('a'),
+                  randomKey = $.SrBuj.Util.randomCode(6);
+
+              _srbujLink.id = ['_srbujLink', randomKey].join('_');
               if (user_options.force_refresh) {
-                var params     = { key: $.SrBuj.Util.randomCode(6) }
+                var params     = { key: randomKey }
                   , urlParams  = $.param(params)
                   , splitedUrl = user_options.href.split(/\?.+/)
                   , joinChar   = (splitedUrl.length > 1) ? '&'

--- a/lib/assets/javascripts/SrBuj.js
+++ b/lib/assets/javascripts/SrBuj.js
@@ -206,8 +206,10 @@
              gMsg.textContent = options.message;
              $('body').append(gMsg);
              gMsg.className += [' alert', options.side || 'right', options.position ||  'bottom', 'srbuj-notify' ].join(' ').toLowerCase();
-             options.time = Number(options.time) > 0 ? options.time : 2000;
-             $.SrBuj.gMsg_interval = window.setInterval( $.SrBuj.Util.removeNotify, options.time );
+             if (options.time != -1) {
+               options.time = Number(options.time) > 0 ? options.time : 2000;
+               $.SrBuj.gMsg_interval = window.setInterval( $.SrBuj.Util.removeNotify, options.time );
+             }
           },
           removeNotify: function(){
             $('#_growlingMsg').removeClass('srbuj-notify');

--- a/test/changeDom.js
+++ b/test/changeDom.js
@@ -1,4 +1,5 @@
 describe('SrBuj changeDom function', function(){
+
   beforeEach(function(){
     document.body = document.createElement('body')
     html = '<div><span id="proof"></span></div>'
@@ -7,16 +8,16 @@ describe('SrBuj changeDom function', function(){
     proof_element = document.getElementById('proof')
   })
 
-  it('should find version', function(){
-      expect($.SrBuj.version).toBe('0.9.2')
+  it('show version', function(){
+    expect($.SrBuj.version).toBe('0.9.2')
   })
 
-  it('should delete target', function(){
+  it('delete target', function(){
     $.SrBuj.changeDom('DELETE', $(proof_element))
     expect(document.getElementById('proof')).toBeNull()
   })
 
-  it('should replace target', function(){
+  it('replace target', function(){
     expect(document.body.innerHTML).not.toContain('replaced')
 
     $.SrBuj.changeDom('PATCH', $(proof_element), 'replaced')
@@ -25,7 +26,7 @@ describe('SrBuj changeDom function', function(){
     expect(document.body.innerHTML).toContain('replaced')
   })
 
-  it('should append to target', function(){
+  it('append to target', function(){
     expect(document.body.innerHTML).not.toContain('appended')
 
     $.SrBuj.changeDom('POST', $(proof_element), 'appended')
@@ -34,7 +35,7 @@ describe('SrBuj changeDom function', function(){
     expect(document.body.innerHTML).toContain('appended')
   })
 
-  it('should "html" target', function(){
+  it('"html" target', function(){
     expect(document.body.innerHTML).not.toContain('htmling')
 
     $.SrBuj.changeDom('SAMPLE', $(proof_element), 'htmling')
@@ -42,4 +43,32 @@ describe('SrBuj changeDom function', function(){
     expect(document.getElementById('proof')).not.toBeNull()
     expect(document.body.innerHTML).toContain('htmling')
   })
+
+  it('raises a notification', function(){
+    jasmine.Clock.useMock()
+    $.SrBuj.Util.notify({ message: 'This is madness!', time: 20 })
+
+    jasmine.Clock.tick(30)
+    expect(document.getElementsByClassName('srbuj-notify').length).not.toBeGreaterThan(0)
+  })
+
+  it('raises a notification that stays', function(){
+    jasmine.Clock.useMock()
+    $.SrBuj.Util.notify({ message: 'Sticked is madness!', time: -1 })
+
+    jasmine.Clock.tick(30)
+    expect(document.getElementsByClassName('srbuj-notify').length).toBeGreaterThan(0)
+  })
+
+  it('prevent 304 on browsers cache', function() {
+    for (var i = 0; i < 2; i++) {
+      $.SrBuj.Util.link({ href: '/', target: true, force_refresh: true })
+    }
+
+    var links = document.querySelectorAll('[id=_srbujLink]')
+
+    expect(links.length).toEqual(2)
+    expect(links[0].href).not.toEqual(links[1].href)
+  });
+
 })

--- a/test/changeDom.js
+++ b/test/changeDom.js
@@ -65,7 +65,7 @@ describe('SrBuj changeDom function', function(){
       $.SrBuj.Util.link({ href: '/', target: true, force_refresh: true })
     }
 
-    var links = document.querySelectorAll('[id=_srbujLink]')
+    var links = document.querySelectorAll('[id^=_srbujLink_]')
 
     expect(links.length).toEqual(2)
     expect(links[0].href).not.toEqual(links[1].href)


### PR DESCRIPTION
- Setting `force_refresh: true` prevent 304 on browser's cache on `$.SrBuj.Util.link`
- Links generated by `$.SrBuj.Util.link` have unique ids.
- There was a problem with the encoding on notify messages, now the message is decoded to UTF-8 by default and this feature can be disabled by setting `raw: true` on js_notify helper.
- Setting `remove: true` on js_notify helper will remove all notifications.
- By setting `time: -1` the notification will stick like a regular Rails flash message.
- Some tests
